### PR TITLE
Bug fix: Amended the payment event listener

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -105,8 +105,9 @@ payPal.style.display = "";
 const bitcoin = document.getElementById("bitcoin");
 bitcoin.style.display = "none";
 
+document.querySelector("[value='select method']").style.display = "none";
+
 payment.addEventListener('click', (event) => {
-  payment.remove(0)
   const paymentType = event.target.value;
   if (paymentType === "credit card") {
     creditCard.style.display = "";


### PR DESCRIPTION
When a user clicks on the payment drop down the code was set to remove the first option on the menu. 
Every time an option was removed the index shifts meaning that each option is removed on each click.

I have taken the code outside of the event listener & set the payment method option to display = none. 