### PR TITLE
Updated payment event listener

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -137,7 +137,7 @@ bitcoin.style.display = "none";
 
 document.querySelector("[value='select method']").style.display = "none";
 
-payment.addEventListener('click', (event) => {
+payment.addEventListener('change', (event) => {
   const paymentType = event.target.value;
   if (paymentType === "credit card") {
     creditCard.style.display = "";


### PR DESCRIPTION
Updated to change event rather than click. 
Click will not update the payment details until the user clicks a different option again.